### PR TITLE
Fix/time granularity enum

### DIFF
--- a/dbtsl/models/time.py
+++ b/dbtsl/models/time.py
@@ -1,20 +1,15 @@
 from enum import Enum
 
-from typing_extensions import override
 
-from dbtsl.models.base import DeprecatedMixin
+from dbtsl.models.base import deprecated
 
 
-class TimeGranularity(str, DeprecatedMixin, Enum):
+@deprecated(
+    "Since the introduction of custom time granularity, the `TimeGranularity` enum is deprecated. "
+    "Please just use strings to represent time grains."
+)
+class TimeGranularity(str, Enum):
     """A time granularity."""
-
-    @override
-    @classmethod
-    def _deprecation_message(cls) -> str:
-        return (
-            "Since the introduction of custom time granularity, the `TimeGranularity` enum is deprecated. "
-            "Please just use strings to represent time grains."
-        )
 
     NANOSECOND = "NANOSECOND"
     MICROSECOND = "MICROSECOND"


### PR DESCRIPTION
DeprecatedMixin breaks in Python 3.11.0. Replacing it with decorator for better compatibility